### PR TITLE
REPR-1730: Adding drupal_exit() to avoid double rendering

### DIFF
--- a/lib/features/reps_core/reps_core.module
+++ b/lib/features/reps_core/reps_core.module
@@ -851,5 +851,6 @@ function reps_core_views_pre_render(&$view) {
   // REPR-1730 deny access to nodequeue views for anonymous.
   if ($view->tag == 'nodequeue' && user_is_anonymous()) {
     drupal_access_denied();
+    drupal_exit();
   }
 }


### PR DESCRIPTION
…h was wrongly rendered